### PR TITLE
Fix crash on Xcode 11.2b

### DIFF
--- a/Demo/ASCollectionViewDemo/Views/Compositional/GridView.swift
+++ b/Demo/ASCollectionViewDemo/Views/Compositional/GridView.swift
@@ -65,6 +65,10 @@ struct GridView: View
 			{ item in
 				ASRemoteImageView(item.squareThumbURL)
 					.aspectRatio(1, contentMode: .fill)
+                    .contextMenu {
+                        Text("Test item")
+                        Text("Another item")
+                }
 			}
 		}
 	}

--- a/Demo/ASCollectionViewDemo/Views/Feed/PostView.swift
+++ b/Demo/ASCollectionViewDemo/Views/Feed/PostView.swift
@@ -77,8 +77,10 @@ struct PostView: View
 			{
 				if !self.captionExpanded
 				{
-					self.captionExpanded = true
-					self.invalidateCellLayout()
+                    withAnimation() {
+                        self.captionExpanded = true
+                        self.invalidateCellLayout()
+                    }
 				}
 			}
 			Text("View all \(post.comments) comments").foregroundColor(Color(.systemGray))
@@ -103,6 +105,7 @@ struct PostView: View
 				)
 			buttonBar
 			textContent
+            Spacer()
 		}
 		.padding([.top, .bottom])
 	}

--- a/Demo/ASCollectionViewDemo/Views/Orthogonal/OrthoView.swift
+++ b/Demo/ASCollectionViewDemo/Views/Orthogonal/OrthoView.swift
@@ -72,7 +72,8 @@ struct OrthoView: View
 														   heightDimension: .estimated(34)),
 						elementKind: UICollectionView.elementKindSectionHeader,
 						alignment: .top)
-					header.contentInsets = nestedGroup.contentInsets
+                    header.contentInsets.leading = nestedGroup.contentInsets.leading
+                    header.contentInsets.trailing = nestedGroup.contentInsets.trailing
 					
 					let section = NSCollectionLayoutSection(group: nestedGroup)
 					section.boundarySupplementaryItems = [header]
@@ -110,7 +111,8 @@ struct OrthoView: View
 														   heightDimension: .estimated(34)),
 						elementKind: UICollectionView.elementKindSectionHeader,
 						alignment: .top)
-					header.contentInsets = nestedGroup.contentInsets
+                    header.contentInsets.leading = nestedGroup.contentInsets.leading
+                    header.contentInsets.trailing = nestedGroup.contentInsets.trailing
 					
 					let section = NSCollectionLayoutSection(group: nestedGroup)
 					section.boundarySupplementaryItems = [header]


### PR DESCRIPTION
- Fix crash on Xcode 11.2b

- Demo project:
    - add context menu to grid page
    - fix warnings regarding setting contentInsets on estimated axis