### PR TITLE
Make importable by iOS 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(name: "ASCollectionView",
-                      platforms: [.iOS(.v13)],
+                      platforms: [.iOS(.v11)],
                       products: [// Products define the executables and libraries produced by a package, and make them visible to other packages.
                       	.library(name: "ASCollectionView",
                       	         targets: ["ASCollectionView"])

--- a/Sources/ASCollectionView/ASCollectionView+ShrinkToFit.swift
+++ b/Sources/ASCollectionView/ASCollectionView+ShrinkToFit.swift
@@ -1,13 +1,13 @@
 // ASCollectionView. Created by Apptek Studios 2019
 
 import SwiftUI
-
+@available(iOS 13.0, *)
 protocol ContentSize
 {
 	var contentSize: Binding<CGSize?>? { get set }
 }
 
-
+@available(iOS 13.0, *)
 public enum ShrinkDimension
 {
 	case horizontal
@@ -23,7 +23,7 @@ public enum ShrinkDimension
 		self == .horizontal
 	}
 }
-
+@available(iOS 13.0, *)
 struct SelfSizingWrapper<Content: View & ContentSize>: View
 {
 	var contentSize: Binding<CGSize?>
@@ -52,7 +52,7 @@ struct SelfSizingWrapper<Content: View & ContentSize>: View
 				alignment: .topLeading)
 	}
 }
-
+@available(iOS 13.0, *)
 public extension ASCollectionView
 {
 	func shrinkToContentSize(isEnabled: Bool, _ contentSize: Binding<CGSize?>, dimensionToShrink: ShrinkDimension) -> some View

--- a/Sources/ASCollectionView/ASCollectionView.swift
+++ b/Sources/ASCollectionView/ASCollectionView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 // MARK: Init for single-section CV
 
+@available(iOS 13.0, *)
 extension ASCollectionView where SectionID == Int
 {
 	/**
@@ -59,6 +60,7 @@ extension ASCollectionView where SectionID == Int
 	}
 }
 
+@available(iOS 13.0, *)
 public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentable, ContentSize
 {
 	public typealias Section = ASCollectionViewSection<SectionID>
@@ -545,6 +547,7 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 // MARK: OnReachedBoundary support
 
+@available(iOS 13.0, *)
 extension ASCollectionView.Coordinator
 {
 	public func scrollViewDidScroll(_ scrollView: UIScrollView)
@@ -593,6 +596,7 @@ extension ASCollectionView.Coordinator
 
 // MARK: Modifer: Custom Delegate
 
+@available(iOS 13.0, *)
 public extension ASCollectionView
 {
 	/// Use this modifier to assign a custom delegate type (subclass of ASCollectionViewDelegate). This allows support for old UICollectionViewLayouts that require a delegate.
@@ -606,6 +610,7 @@ public extension ASCollectionView
 
 // MARK: Modifer: Layout Invalidation
 
+@available(iOS 13.0, *)
 public extension ASCollectionView
 {
 	/// For use in cases where you would like to change layout settings in response to a change in variables referenced by your layout closure.
@@ -630,6 +635,8 @@ public extension ASCollectionView
 		return this
 	}
 }
+
+@available(iOS 13.0, *)
 // MARK: Coordinator Protocol
 internal protocol ASCollectionViewCoordinator: AnyObject
 {
@@ -654,6 +661,7 @@ internal protocol ASCollectionViewCoordinator: AnyObject
 
 // MARK: Custom Prefetching Implementation
 
+@available(iOS 13.0, *)
 extension ASCollectionView.Coordinator
 {
 	func setupPrefetching()
@@ -728,6 +736,7 @@ extension ASCollectionView.Coordinator
 	}
 }
 
+@available(iOS 13.0, *)
 public enum ASCollectionViewScrollPosition
 {
 	case top
@@ -737,6 +746,7 @@ public enum ASCollectionViewScrollPosition
 	case centerOnIndexPath(_: IndexPath)
 }
 
+@available(iOS 13.0, *)
 public class AS_CollectionViewController: UIViewController
 {
 	weak var coordinator: ASCollectionViewCoordinator?
@@ -818,6 +828,7 @@ public class AS_CollectionViewController: UIViewController
 	}
 }
 
+@available(iOS 13.0, *)
 public extension ASCollectionView
 {
 	func layout(_ layout: Layout) -> Self

--- a/Sources/ASCollectionView/ASCollectionViewCells.swift
+++ b/Sources/ASCollectionView/ASCollectionViewCells.swift
@@ -3,6 +3,7 @@
 import Foundation
 import SwiftUI
 
+@available(iOS 13.0, *)
 class ASCollectionViewCell: UICollectionViewCell
 {
 	var hostingController: ASHostingControllerProtocol?
@@ -94,6 +95,7 @@ class ASCollectionViewCell: UICollectionViewCell
 	}
 }
 
+@available(iOS 13.0, *)
 class ASCollectionViewSupplementaryView: UICollectionReusableView
 {
 	var hostingController: ASHostingControllerProtocol?

--- a/Sources/ASCollectionView/ASCollectionViewDecoration.swift
+++ b/Sources/ASCollectionView/ASCollectionViewDecoration.swift
@@ -3,11 +3,13 @@
 import Foundation
 import SwiftUI
 
+@available(iOS 13.0, *)
 public protocol Decoration: View
 {
 	init()
 }
 
+@available(iOS 13.0, *)
 class ASCollectionViewDecoration<Content: Decoration>: ASCollectionViewSupplementaryView
 {
 	override init(frame: CGRect)

--- a/Sources/ASCollectionView/ASCollectionViewDelegate.swift
+++ b/Sources/ASCollectionView/ASCollectionViewDelegate.swift
@@ -3,6 +3,8 @@
 import Foundation
 import SwiftUI
 
+
+@available(iOS 13.0, *)
 /// ASCollectionViewDelegate: Subclass this to create a custom delegate (eg. for supporting UICollectionViewLayouts that default to using the collectionView delegate)
 open class ASCollectionViewDelegate: NSObject, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout
 {
@@ -70,6 +72,7 @@ open class ASCollectionViewDelegate: NSObject, UICollectionViewDelegate, UIColle
 	 */
 }
 
+@available(iOS 13.0, *)
 extension ASCollectionViewDelegate: UICollectionViewDragDelegate, UICollectionViewDropDelegate
 {
 	public func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem]

--- a/Sources/ASCollectionView/ASCollectionViewLayout.swift
+++ b/Sources/ASCollectionView/ASCollectionViewLayout.swift
@@ -4,6 +4,7 @@ import Foundation
 import SwiftUI
 import UIKit
 
+@available(iOS 13.0, *)
 /// If building a custom layout, you can conform to this protocol to tell ASCollectionLayout which dimensions should be self-sized (default is both)
 public protocol ASCollectionViewLayoutProtocol
 {
@@ -13,9 +14,13 @@ public protocol ASCollectionViewLayoutProtocol
 
 // MARK: Public Typealias for layout closures
 
+@available(iOS 13.0, *)
 public typealias CompositionalLayout<SectionID: Hashable> = ((_ sectionID: SectionID) -> ASCollectionLayoutSection)
+
+@available(iOS 13.0, *)
 public typealias CompositionalLayoutIgnoringSections = (() -> ASCollectionLayoutSection)
 
+@available(iOS 13.0, *)
 public struct ASCollectionLayout<SectionID: Hashable>
 {
 	enum LayoutType
@@ -106,6 +111,7 @@ public struct ASCollectionLayout<SectionID: Hashable>
 	}
 }
 
+@available(iOS 13.0, *)
 public extension ASCollectionLayout
 {
 	func decorationView<Content: View & Decoration>(_ viewType: Content.Type, forDecorationViewOfKind elementKind: String) -> Self
@@ -116,6 +122,7 @@ public extension ASCollectionLayout
 	}
 }
 
+@available(iOS 13.0, *)
 public struct ASCollectionLayoutSection
 {
 	public init(_ sectionLayout: @escaping () -> NSCollectionLayoutSection)
@@ -145,6 +152,7 @@ public struct ASCollectionLayoutSection
 	}
 }
 
+@available(iOS 13.0, *)
 public extension ASCollectionLayoutSection
 {
 	static func list(
@@ -192,6 +200,7 @@ public extension ASCollectionLayoutSection
 	}
 }
 
+@available(iOS 13.0, *)
 public extension ASCollectionLayoutSection
 {
 	enum GridLayoutMode
@@ -266,6 +275,7 @@ public extension ASCollectionLayoutSection
 	}
 }
 
+@available(iOS 13.0, *)
 public extension ASCollectionLayoutSection
 {
 	static func orthogonalGrid(

--- a/Sources/ASCollectionView/ASCollectionViewSection.swift
+++ b/Sources/ASCollectionView/ASCollectionViewSection.swift
@@ -3,12 +3,14 @@
 import Foundation
 import SwiftUI
 
+@available(iOS 13.0, *)
 public struct ASCollectionViewStaticContent: Identifiable
 {
 	public var id: Int
 	public var view: AnyView
 }
 
+@available(iOS 13.0, *)
 public struct ASCollectionViewItemUniqueID: Hashable
 {
 	var sectionIDHash: Int
@@ -20,6 +22,7 @@ public struct ASCollectionViewItemUniqueID: Hashable
 	}
 }
 
+@available(iOS 13.0, *)
 public struct ASCollectionViewSection<SectionID: Hashable>: Hashable
 {
 	public var id: SectionID
@@ -81,7 +84,7 @@ public struct ASCollectionViewSection<SectionID: Hashable>: Hashable
 }
 
 // MARK: SUPPLEMENTARY VIEWS - INTERNAL
-
+@available(iOS 13.0, *)
 internal extension ASCollectionViewSection
 {
 	mutating func setHeaderView<Content: View>(_ view: Content?)
@@ -118,6 +121,7 @@ internal extension ASCollectionViewSection
 
 // MARK: SUPPLEMENTARY VIEWS - PUBLIC MODIFIERS
 
+@available(iOS 13.0, *)
 public extension ASCollectionViewSection
 {
 	func sectionHeader<Content: View>(content: () -> Content?) -> Self
@@ -152,7 +156,7 @@ public extension ASCollectionViewSection
 }
 
 // MARK: STATIC CONTENT SECTION
-
+@available(iOS 13.0, *)
 public extension ASCollectionViewSection
 {
 	/**
@@ -192,7 +196,7 @@ public extension ASCollectionViewSection
 }
 
 // MARK: IDENTIFIABLE DATA SECTION
-
+@available(iOS 13.0, *)
 public extension ASCollectionViewSection
 {
 	/**

--- a/Sources/ASCollectionView/ASHostingController.swift
+++ b/Sources/ASCollectionView/ASHostingController.swift
@@ -3,6 +3,7 @@
 import Foundation
 import SwiftUI
 
+@available(iOS 13.0, *)
 internal struct ASHostingControllerModifier: ViewModifier
 {
 	var invalidateCellLayout: (() -> Void) = {}
@@ -13,6 +14,7 @@ internal struct ASHostingControllerModifier: ViewModifier
 	}
 }
 
+@available(iOS 13.0, *)
 internal protocol ASHostingControllerProtocol
 {
 	var viewController: UIViewController { get }
@@ -20,6 +22,7 @@ internal protocol ASHostingControllerProtocol
 	func sizeThatFits(in size: CGSize, selfSizeHorizontal: Bool, selfSizeVertical: Bool) -> CGSize
 }
 
+@available(iOS 13.0, *)
 internal class ASHostingController<ViewType: View>: ASHostingControllerProtocol
 {
 	init(_ view: ViewType)

--- a/Sources/ASCollectionView/ASSectionDataSource.swift
+++ b/Sources/ASCollectionView/ASSectionDataSource.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 import SwiftUI
-
+@available(iOS 13.0, *)
 internal protocol ASSectionDataSourceProtocol
 {
 	func getIndexPaths(withSectionIndex sectionIndex: Int) -> [IndexPath]
@@ -19,7 +19,7 @@ internal protocol ASSectionDataSourceProtocol
 	var dragEnabled: Bool { get }
 	var dropEnabled: Bool { get }
 }
-
+@available(iOS 13.0, *)
 public enum CellEvent<Data>
 {
 	/// Respond by starting necessary prefetch operations for this data to be displayed soon (eg. download images)
@@ -34,17 +34,21 @@ public enum CellEvent<Data>
 	/// Called when an item is disappearing from the screen
 	case onDisappear(item: Data)
 }
-
+@available(iOS 13.0, *)
 public enum DragDrop<Data>
 {
 	case onRemoveItem(indexPath: IndexPath)
 	case onAddItems(items: [Data], atIndexPath: IndexPath)
 }
 
+@available(iOS 13.0, *)
 public typealias OnCellEvent<Data> = ((_ event: CellEvent<Data>) -> Void)
+@available(iOS 13.0, *)
 public typealias OnDragDrop<Data> = ((_ event: DragDrop<Data>) -> Void)
+@available(iOS 13.0, *)
 public typealias ItemProvider<Data> = ((_ item: Data) -> NSItemProvider)
 
+@available(iOS 13.0, *)
 public struct CellContext
 {
 	public var isSelected: Bool
@@ -52,6 +56,7 @@ public struct CellContext
 	public var isLastInSection: Bool
 }
 
+@available(iOS 13.0, *)
 internal struct ASSectionDataSource<DataCollection: RandomAccessCollection, DataID, Content>: ASSectionDataSourceProtocol where DataID: Hashable, Content: View, DataCollection.Index == Int
 {
 	typealias Data = DataCollection.Element

--- a/Sources/ASCollectionView/ASTableView.swift
+++ b/Sources/ASCollectionView/ASTableView.swift
@@ -3,6 +3,7 @@
 import Combine
 import SwiftUI
 
+@available(iOS 13.0, *)
 extension ASTableView where SectionID == Int
 {
 	/**
@@ -60,8 +61,10 @@ extension ASTableView where SectionID == Int
 	}
 }
 
+@available(iOS 13.0, *)
 public typealias ASTableViewSection<SectionID: Hashable> = ASCollectionViewSection<SectionID>
 
+@available(iOS 13.0, *)
 public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable
 {
 	public typealias Section = ASTableViewSection<SectionID>

--- a/Sources/ASCollectionView/ASTableViewCells.swift
+++ b/Sources/ASCollectionView/ASTableViewCells.swift
@@ -3,6 +3,7 @@
 import Foundation
 import SwiftUI
 
+@available(iOS 13.0, *)
 class ASTableViewCell: UITableViewCell
 {
 	var hostingController: ASHostingControllerProtocol?
@@ -83,6 +84,7 @@ class ASTableViewCell: UITableViewCell
 	}
 }
 
+@available(iOS 13.0, *)
 class ASTableViewSupplementaryView: UITableViewHeaderFooterView
 {
 	var hostingController: ASHostingControllerProtocol?

--- a/Sources/ASCollectionView/ASWaterfallLayout.swift
+++ b/Sources/ASCollectionView/ASWaterfallLayout.swift
@@ -3,6 +3,7 @@
 import Foundation
 import UIKit
 
+@available(iOS 13.0, *)
 /// WORK IN PROGRESS
 public class ASWaterfallLayout: UICollectionViewLayout, ASCollectionViewLayoutProtocol
 {
@@ -230,6 +231,7 @@ public class ASWaterfallLayout: UICollectionViewLayout, ASCollectionViewLayoutPr
 
 // MARK: Delegate
 
+@available(iOS 13.0, *)
 public protocol ASWaterfallLayoutDelegate
 {
 	func heightForCell(at indexPath: IndexPath, context: ASWaterfallLayout.CellLayoutContext) -> CGFloat

--- a/Sources/ASCollectionView/EnvironmentKeys.swift
+++ b/Sources/ASCollectionView/EnvironmentKeys.swift
@@ -2,52 +2,52 @@
 
 import Foundation
 import SwiftUI
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyInvalidateCellLayout: EnvironmentKey
 {
 	static let defaultValue: (() -> Void) = {}
 }
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyASScrollIndicatorsEnabled: EnvironmentKey
 {
 	static let defaultValue: Bool = true
 }
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyASContentInsets: EnvironmentKey
 {
 	static let defaultValue: UIEdgeInsets = .zero
 }
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyASTableViewSeparatorsEnabled: EnvironmentKey
 {
 	static let defaultValue: Bool = true
 }
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyASTableViewOnReachedBottom: EnvironmentKey
 {
 	static let defaultValue: (() -> Void) = {}
 }
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyASCollectionViewOnReachedBoundary: EnvironmentKey
 {
 	static let defaultValue: ((Boundary) -> Void) = { _ in }
 }
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyASAlwaysBounceVertical: EnvironmentKey
 {
 	static let defaultValue: Bool = false
 }
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyASAlwaysBounceHorizontal: EnvironmentKey
 {
 	static let defaultValue: Bool = false
 }
-
+@available(iOS 13.0, *)
 struct EnvironmentKeyASInitialScrollPosition: EnvironmentKey
 {
 	static let defaultValue: ASCollectionViewScrollPosition? = nil
 }
-
+@available(iOS 13.0, *)
 public extension EnvironmentValues
 {
 	var invalidateCellLayout: () -> Void
@@ -104,7 +104,7 @@ public extension EnvironmentValues
 		set { self[EnvironmentKeyASInitialScrollPosition.self] = newValue }
 	}
 }
-
+@available(iOS 13.0, *)
 public extension View
 {
 	/// Set whether to show scroll indicators for the ASCollectionView/ASTableView

--- a/Sources/ASCollectionView/Function Builders/SectionArrayBuilder.swift
+++ b/Sources/ASCollectionView/Function Builders/SectionArrayBuilder.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 import SwiftUI
-
+@available(iOS 13.0, *)
 @_functionBuilder
 public struct SectionArrayBuilder<SectionID> where SectionID: Hashable
 {

--- a/Sources/ASCollectionView/Function Builders/ViewArrayBuilder.swift
+++ b/Sources/ASCollectionView/Function Builders/ViewArrayBuilder.swift
@@ -3,6 +3,7 @@
 import Foundation
 import SwiftUI
 
+@available(iOS 13.0, *)
 @_functionBuilder
 public struct ViewArrayBuilder
 {


### PR DESCRIPTION
This makes the package importable by a mixed project compiled for an older release since we still don't have optional imports by iOS release.