### PR TITLE
fix: set optional values to nil to fix not initialized error

### DIFF
--- a/Sources/ASCollectionView/Config/ASDragDropConfig.swift
+++ b/Sources/ASCollectionView/Config/ASDragDropConfig.swift
@@ -13,13 +13,13 @@ public struct ASDragDropConfig<Data>
 	var dropEnabled: Bool = false
 	var reorderingEnabled: Bool = false
 
-	var dragItemProvider: ((_ item: Data) -> NSItemProvider?)?
-	var shouldMoveItem: ((_ sourceIndexPath: IndexPath, _ destinationIndexPath: IndexPath) -> Bool)?
+	var dragItemProvider: ((_ item: Data) -> NSItemProvider?)? = nil
+	var shouldMoveItem: ((_ sourceIndexPath: IndexPath, _ destinationIndexPath: IndexPath) -> Bool)? = nil
 
 	/// An optional closure that you can use to decide what to do with a dropped item.
 	/// Return nil if you want to ignore the drop.
 	/// Return an item (of the same type as your section data) if you want to insert a row.
 	/// `sourceItem`: If the drop originated from a cell with the same data source, this will provide the original item that has been dragged
 	/// `dragItem`: This is the further information provided by UIKit. For example, if a drag came from another app, you could deal with that using this.
-	var dropItemProvider: ((_ sourceItem: Data?, _ dragItem: UIDragItem) -> Data?)?
+	var dropItemProvider: ((_ sourceItem: Data?, _ dragItem: UIDragItem) -> Data?)? = nil
 }

--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -23,21 +23,21 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 	internal var delegateInitialiser: (() -> ASCollectionViewDelegate) = ASCollectionViewDelegate.init
 
-	internal var contentSizeTracker: ContentSizeTracker?
+	internal var contentSizeTracker: ContentSizeTracker? = nil
 
-	internal var onScrollCallback: OnScrollCallback?
-	internal var onReachedBoundaryCallback: OnReachedBoundaryCallback?
+	internal var onScrollCallback: OnScrollCallback? = nil
+	internal var onReachedBoundaryCallback: OnReachedBoundaryCallback? = nil
 
 	internal var horizontalScrollIndicatorEnabled: Bool = true
 	internal var verticalScrollIndicatorEnabled: Bool = true
 	internal var contentInsets: UIEdgeInsets = .zero
 
-	internal var onPullToRefresh: ((_ endRefreshing: @escaping (() -> Void)) -> Void)?
+	internal var onPullToRefresh: ((_ endRefreshing: @escaping (() -> Void)) -> Void)? = nil
 
 	internal var alwaysBounceVertical: Bool = false
 	internal var alwaysBounceHorizontal: Bool = false
 
-	internal var initialScrollPosition: ASCollectionViewScrollPosition?
+	internal var initialScrollPosition: ASCollectionViewScrollPosition? = nil
 
 	internal var animateOnDataRefresh: Bool = true
 

--- a/Sources/ASCollectionView/Implementation/ASSection.swift
+++ b/Sources/ASCollectionView/Implementation/ASSection.swift
@@ -43,9 +43,9 @@ public struct ASSection<SectionID: Hashable>
 
 	// Only relevant for ASTableView
 	var disableDefaultTheming: Bool = false
-	var tableViewSeparatorInsets: UIEdgeInsets?
-	var estimatedHeaderHeight: CGFloat?
-	var estimatedFooterHeight: CGFloat?
+	var tableViewSeparatorInsets: UIEdgeInsets? = nil
+	var estimatedHeaderHeight: CGFloat? = nil
+	var estimatedFooterHeight: CGFloat? = nil
 }
 
 // MARK: SUPPLEMENTARY VIEWS - INTERNAL

--- a/Sources/ASCollectionView/Implementation/ASTableView.swift
+++ b/Sources/ASCollectionView/Implementation/ASTableView.swift
@@ -23,15 +23,15 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 
 	// MARK: Private vars set by public modifiers
 
-	internal var onScrollCallback: OnScrollCallback?
-	internal var onReachedBottomCallback: OnReachedBottomCallback?
+	internal var onScrollCallback: OnScrollCallback? = nil
+	internal var onReachedBottomCallback: OnReachedBottomCallback? = nil
 
 	internal var scrollIndicatorEnabled: Bool = true
 	internal var contentInsets: UIEdgeInsets = .zero
 
 	internal var separatorsEnabled: Bool = true
 
-	internal var onPullToRefresh: ((_ endRefreshing: @escaping (() -> Void)) -> Void)?
+	internal var onPullToRefresh: ((_ endRefreshing: @escaping (() -> Void)) -> Void)? = nil
 
 	internal var alwaysBounce: Bool = false
 	internal var animateOnDataRefresh: Bool = true
@@ -43,7 +43,7 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 	@Environment(\.invalidateCellLayout) var invalidateParentCellLayout // Call this if using content size binding (nested inside another ASCollectionView)
 
 	// Other
-	var contentSizeTracker: ContentSizeTracker?
+	var contentSizeTracker: ContentSizeTracker? = nil
 
 	public func makeUIViewController(context: Context) -> AS_TableViewController
 	{


### PR DESCRIPTION
I ran into an issue installing the package via SPM (https://github.com/apptekstudios/ASCollectionView/issues/147) on 1.6.3

The package would not compile due to some optional values not being initialized. Setting their default initialized value to `nil`