### PR TITLE
Add backgroundColor(_:) modifier to ASCollectionView

### DIFF
--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -67,6 +67,14 @@ public extension ASCollectionView
 		return this
 	}
 
+	/// Sets the collection view's background color
+	func backgroundColor(_ color: UIColor?) -> Self
+	{
+		var this = self
+		this.backgroundColor = color
+		return this
+	}
+
 	/// Set whether to show scroll indicators
 	func scrollIndicatorsEnabled(horizontal: Bool = true, vertical: Bool = true) -> Self
 	{

--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -28,6 +28,8 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 	internal var onScrollCallback: OnScrollCallback?
 	internal var onReachedBoundaryCallback: OnReachedBoundaryCallback?
 
+	internal var backgroundColor: UIColor?
+
 	internal var horizontalScrollIndicatorEnabled: Bool = true
 	internal var verticalScrollIndicatorEnabled: Bool = true
 	internal var contentInsets: UIEdgeInsets = .zero
@@ -184,6 +186,7 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 		func updateCollectionViewSettings(_ collectionView: UICollectionView)
 		{
+            assignIfChanged(collectionView, \.backgroundColor, newValue: parent.backgroundColor)
 			assignIfChanged(collectionView, \.dragInteractionEnabled, newValue: true)
 			assignIfChanged(collectionView, \.alwaysBounceVertical, newValue: parent.alwaysBounceVertical)
 			assignIfChanged(collectionView, \.alwaysBounceHorizontal, newValue: parent.alwaysBounceHorizontal)


### PR DESCRIPTION
This pull request adds a background color modifier to `ASCollectionView` to allow consumers to specify background colors that share the standard system behaviors of extending behind navigation bars and allowing `ASCollectionView` to make large title navigation bars collapse automatically during scroll.

I know this solution isn't very SwiftUI-y, but I couldn't come up with another simple solution to the problem described in #171.

Closes #171