### PR TITLE
Update collection view selection handling

### DIFF
--- a/Demo/ASCollectionViewDemo.xcodeproj/project.pbxproj
+++ b/Demo/ASCollectionViewDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5708D2572504FCC50014C671 /* OnChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5708D2562504FCC50014C671 /* OnChange.swift */; };
 		B8268B522363EF03008C99A3 /* RemindersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8268B512363EF03008C99A3 /* RemindersScreen.swift */; };
 		B8268B542363EF1B008C99A3 /* GroupLarge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8268B532363EF1B008C99A3 /* GroupLarge.swift */; };
 		B8268B562363EF25008C99A3 /* GroupSmall.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8268B552363EF25008C99A3 /* GroupSmall.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5708D2562504FCC50014C671 /* OnChange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnChange.swift; sourceTree = "<group>"; };
 		B8268B512363EF03008C99A3 /* RemindersScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemindersScreen.swift; sourceTree = "<group>"; };
 		B8268B532363EF1B008C99A3 /* GroupLarge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupLarge.swift; sourceTree = "<group>"; };
 		B8268B552363EF25008C99A3 /* GroupSmall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSmall.swift; sourceTree = "<group>"; };
@@ -158,10 +160,11 @@
 		B86C6F30234B0B9D00522AEF /* Support */ = {
 			isa = PBXGroup;
 			children = (
-				B86C6F31234B0B9D00522AEF /* ASRemoteImageView.swift */,
 				B86C6F32234B0B9D00522AEF /* ASCache.swift */,
 				B86C6F33234B0B9D00522AEF /* ASRemoteImageManager.swift */,
+				B86C6F31234B0B9D00522AEF /* ASRemoteImageView.swift */,
 				B86C6F34234B0B9D00522AEF /* LoremSwiftum.swift */,
+				5708D2562504FCC50014C671 /* OnChange.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 			files = (
 				B8C00A972376350B0066348C /* AdjustableGridScreen.swift in Sources */,
 				B8268B542363EF1B008C99A3 /* GroupLarge.swift in Sources */,
+				5708D2572504FCC50014C671 /* OnChange.swift in Sources */,
 				B86C6F44234B0B9D00522AEF /* ASCache.swift in Sources */,
 				B86C6F4B234B0B9D00522AEF /* AppViews.swift in Sources */,
 				B89129FE235DB71900D8BA90 /* TagsScreen.swift in Sources */,

--- a/Demo/ASCollectionViewDemo/Screens/PhotoGrid/PhotoGridScreen.swift
+++ b/Demo/ASCollectionViewDemo/Screens/PhotoGrid/PhotoGridScreen.swift
@@ -7,7 +7,7 @@ import UIKit
 struct PhotoGridScreen: View
 {
 	@State var data: [Post] = DataSource.postsForGridSection(1, number: 1000)
-	@State var selectedItems: Set<Int> = []
+	@State var selectedIndexes: Set<Int> = []
 
 	@Environment(\.editMode) private var editMode
 	var isEditing: Bool
@@ -22,7 +22,7 @@ struct PhotoGridScreen: View
 		ASCollectionViewSection(
 			id: 0,
 			data: data,
-			selectedItems: $selectedItems,
+			selectedIndexes: $selectedIndexes,
 			onCellEvent: onCellEvent,
 			dragDropConfig: dragDropConfig,
 			contextMenuProvider: contextMenuProvider)
@@ -65,6 +65,8 @@ struct PhotoGridScreen: View
 		ASCollectionView(
 			section: section)
 			.layout(self.layout)
+			.allowsSelection(self.isEditing)
+			.allowsMultipleSelection(self.isEditing)
 			.edgesIgnoringSafeArea(.all)
 			.navigationBarTitle("Explore", displayMode: .large)
 			.navigationBarItems(
@@ -76,7 +78,7 @@ struct PhotoGridScreen: View
 						Button(action: {
 							withAnimation {
 								// We want the cell removal to be animated, so explicitly specify `withAnimation`
-								self.data.remove(atOffsets: IndexSet(self.selectedItems))
+								self.data.remove(atOffsets: IndexSet(self.selectedIndexes))
 							}
 						})
 						{

--- a/Demo/ASCollectionViewDemo/Screens/Waterfall/WaterfallScreen.swift
+++ b/Demo/ASCollectionViewDemo/Screens/Waterfall/WaterfallScreen.swift
@@ -8,7 +8,8 @@ import UIKit
 struct WaterfallScreen: View
 {
 	@State var data: [[Post]] = (0 ... 10).map { DataSource.postsForWaterfallSection($0, number: 100) }
-	@State var selectedItems: [SectionID: Set<Int>] = [:]
+	@State var selectedIndexes: [SectionID: Set<Int>] = [:]
+	@State var selectedPost: Post? = nil // Post being viewed in the detail view
 	@State var columnMinSize: CGFloat = 150
 
 	@Environment(\.editMode) private var editMode
@@ -25,7 +26,7 @@ struct WaterfallScreen: View
 			ASCollectionViewSection(
 				id: offset,
 				data: sectionData,
-				selectedItems: $selectedItems[offset],
+				selectedIndexes: $selectedIndexes[offset],
 				onCellEvent: onCellEvent)
 			{ item, state in
 				GeometryReader
@@ -35,9 +36,9 @@ struct WaterfallScreen: View
 						ASRemoteImageView(item.url)
 							.scaledToFill()
 							.frame(width: geom.size.width, height: geom.size.height)
-							.opacity(state.isSelected ? 0.7 : 1.0)
+							.opacity(self.isEditing && state.isSelected ? 0.7 : 1.0)
 
-						if state.isSelected
+						if self.isEditing && state.isSelected
 						{
 							ZStack
 							{
@@ -91,8 +92,11 @@ struct WaterfallScreen: View
 			ASCollectionView(
 				sections: sections)
 				.layout(self.layout)
+				.allowsMultipleSelection(self.isEditing)
 				.customDelegate(WaterfallScreenLayoutDelegate.init)
 				.contentInsets(.init(top: 0, left: 10, bottom: 10, right: 10))
+				.onChange(of: selectedIndexes, perform: onSelectionChange)
+				.postSheet(item: $selectedPost, onDismiss: { self.selectedIndexes = [:] })
 				.navigationBarTitle("Waterfall Layout", displayMode: .inline)
 				.navigationBarItems(
 					trailing:
@@ -102,7 +106,7 @@ struct WaterfallScreen: View
 						{
 							Button(action: {
 								withAnimation {
-									self.selectedItems.forEach { sectionIndex, selected in
+									self.selectedIndexes.forEach { sectionIndex, selected in
 										self.data[sectionIndex].remove(atOffsets: IndexSet(selected))
 									}
 								}
@@ -114,6 +118,21 @@ struct WaterfallScreen: View
 
 						EditButton()
 				})
+		}
+	}
+
+	func onSelectionChange(_ selection: [SectionID: Set<Int>])
+	{
+		guard !isEditing else { return }
+
+		if let (sectionID, selectedIndexes) = selection.first(where: { !$0.value.isEmpty }),
+			let selectedIndex = selectedIndexes.first
+		{
+			self.selectedPost = self.data[sectionID][selectedIndex]
+		}
+		else
+		{
+			self.selectedPost = nil
 		}
 	}
 
@@ -134,6 +153,20 @@ struct WaterfallScreen: View
 			for item in data
 			{
 				ASRemoteImageManager.shared.cancelLoad(for: item.url)
+			}
+		}
+	}
+}
+
+private extension View
+{
+	func postSheet(item: Binding<Post?>, onDismiss: @escaping () -> Void) -> some View
+	{
+		sheet(item: item, onDismiss: onDismiss) { post in
+			VStack
+			{
+				ASRemoteImageView(post.url)
+					.scaledToFill()
 			}
 		}
 	}

--- a/Demo/ASCollectionViewDemo/Support/OnChange.swift
+++ b/Demo/ASCollectionViewDemo/Support/OnChange.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+extension View
+{
+	func onChange<V: Equatable>(of value: V, perform action: @escaping (V) -> Void) -> some View
+	{
+		OnChange(content: self, value: value, perform: action)
+	}
+}
+
+// `View.onChange(of:perform:)` is only available on iOS 14.0+
+// https://developer.apple.com/documentation/swiftui/view/onchange(of:perform:)
+private struct OnChange<Content: View, V: Equatable>: View
+{
+	private let content: Content
+	private let current: V
+	private let action: (V) -> Void
+
+	@State private var state: ValueState<V>
+
+	init(content: Content, value: V, perform action: @escaping (V) -> Void)
+	{
+		self.content = content
+		current = value
+		self.action = action
+		_state = .init(initialValue: ValueState(value))
+	}
+
+	var body: some View
+	{
+		if state.didChange(current)
+		{
+			DispatchQueue.main.async
+			{
+				self.action(self.current)
+			}
+		}
+		return content
+	}
+}
+
+private final class ValueState<V: Equatable>
+{
+	private var current: V
+
+	init(_ value: V)
+	{
+		current = value
+	}
+
+	func didChange(_ new: V) -> Bool
+	{
+		guard new != current else { return false }
+		current = new
+		return true
+	}
+}

--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -132,6 +132,22 @@ public extension ASCollectionView
 		this.maintainScrollPositionOnOrientationChange = true
 		return this
 	}
+
+	/// Set whether the ASCollectionView should allow selection, default is true
+	func allowsSelection(_ allowsSelection: Bool) -> Self
+	{
+		var this = self
+		this.allowsSelection = allowsSelection
+		return this
+	}
+
+	/// Set whether the ASCollectionView should allow multiple selection, default is false
+	func allowsMultipleSelection(_ allowsMultipleSelection: Bool) -> Self
+	{
+		var this = self
+		this.allowsMultipleSelection = allowsMultipleSelection
+		return this
+	}
 }
 
 // MARK: PUBLIC layout modifier functions

--- a/Sources/ASCollectionView/ASSection+Initialisers.swift
+++ b/Sources/ASCollectionView/ASSection+Initialisers.swift
@@ -24,7 +24,7 @@ public extension ASSection
 		data: DataCollection,
 		dataID dataIDKeyPath: KeyPath<DataCollection.Element, DataID>,
 		container: @escaping ((Content) -> Container),
-		selectedItems: Binding<Set<Int>>? = nil,
+		selectedIndexes: Binding<Set<Int>>? = nil,
 		shouldAllowSelection: ((_ index: Int) -> Bool)? = nil,
 		shouldAllowDeselection: ((_ index: Int) -> Bool)? = nil,
 		onCellEvent: OnCellEvent<DataCollection.Element>? = nil,
@@ -41,7 +41,7 @@ public extension ASSection
 			dataIDKeyPath: dataIDKeyPath,
 			container: container,
 			content: contentBuilder,
-			selectedItems: selectedItems,
+			selectedIndexes: selectedIndexes,
 			shouldAllowSelection: shouldAllowSelection,
 			shouldAllowDeselection: shouldAllowDeselection,
 			onCellEvent: onCellEvent,
@@ -55,7 +55,7 @@ public extension ASSection
 		id: SectionID,
 		data: DataCollection,
 		dataID dataIDKeyPath: KeyPath<DataCollection.Element, DataID>,
-		selectedItems: Binding<Set<Int>>? = nil,
+		selectedIndexes: Binding<Set<Int>>? = nil,
 		shouldAllowSelection: ((_ index: Int) -> Bool)? = nil,
 		shouldAllowDeselection: ((_ index: Int) -> Bool)? = nil,
 		onCellEvent: OnCellEvent<DataCollection.Element>? = nil,
@@ -66,7 +66,7 @@ public extension ASSection
 		@ViewBuilder contentBuilder: @escaping ((DataCollection.Element, ASCellContext) -> Content))
 		where DataCollection.Index == Int
 	{
-		self.init(id: id, data: data, dataID: dataIDKeyPath, container: { $0 }, selectedItems: selectedItems, shouldAllowSelection: shouldAllowSelection, shouldAllowDeselection: shouldAllowDeselection, onCellEvent: onCellEvent, dragDropConfig: dragDropConfig, shouldAllowSwipeToDelete: shouldAllowSwipeToDelete, onSwipeToDelete: onSwipeToDelete, contextMenuProvider: contextMenuProvider, contentBuilder: contentBuilder)
+		self.init(id: id, data: data, dataID: dataIDKeyPath, container: { $0 }, selectedIndexes: selectedIndexes, shouldAllowSelection: shouldAllowSelection, shouldAllowDeselection: shouldAllowDeselection, onCellEvent: onCellEvent, dragDropConfig: dragDropConfig, shouldAllowSwipeToDelete: shouldAllowSwipeToDelete, onSwipeToDelete: onSwipeToDelete, contextMenuProvider: contextMenuProvider, contentBuilder: contentBuilder)
 	}
 }
 
@@ -88,7 +88,7 @@ public extension ASCollectionViewSection
 		id: SectionID,
 		data: DataCollection,
 		container: @escaping ((Content) -> Container),
-		selectedItems: Binding<Set<Int>>? = nil,
+		selectedIndexes: Binding<Set<Int>>? = nil,
 		shouldAllowSelection: ((_ index: Int) -> Bool)? = nil,
 		shouldAllowDeselection: ((_ index: Int) -> Bool)? = nil,
 		onCellEvent: OnCellEvent<DataCollection.Element>? = nil,
@@ -99,13 +99,13 @@ public extension ASCollectionViewSection
 		@ViewBuilder contentBuilder: @escaping ((DataCollection.Element, ASCellContext) -> Content))
 		where DataCollection.Index == Int, DataCollection.Element: Identifiable
 	{
-		self.init(id: id, data: data, dataID: \.id, container: container, selectedItems: selectedItems, shouldAllowSelection: shouldAllowSelection, shouldAllowDeselection: shouldAllowDeselection, onCellEvent: onCellEvent, dragDropConfig: dragDropConfig, shouldAllowSwipeToDelete: shouldAllowSwipeToDelete, onSwipeToDelete: onSwipeToDelete, contextMenuProvider: contextMenuProvider, contentBuilder: contentBuilder)
+		self.init(id: id, data: data, dataID: \.id, container: container, selectedIndexes: selectedIndexes, shouldAllowSelection: shouldAllowSelection, shouldAllowDeselection: shouldAllowDeselection, onCellEvent: onCellEvent, dragDropConfig: dragDropConfig, shouldAllowSwipeToDelete: shouldAllowSwipeToDelete, onSwipeToDelete: onSwipeToDelete, contextMenuProvider: contextMenuProvider, contentBuilder: contentBuilder)
 	}
 
 	init<Content: View, DataCollection: RandomAccessCollection>(
 		id: SectionID,
 		data: DataCollection,
-		selectedItems: Binding<Set<Int>>? = nil,
+		selectedIndexes: Binding<Set<Int>>? = nil,
 		shouldAllowSelection: ((_ index: Int) -> Bool)? = nil,
 		shouldAllowDeselection: ((_ index: Int) -> Bool)? = nil,
 		onCellEvent: OnCellEvent<DataCollection.Element>? = nil,
@@ -116,7 +116,7 @@ public extension ASCollectionViewSection
 		@ViewBuilder contentBuilder: @escaping ((DataCollection.Element, ASCellContext) -> Content))
 		where DataCollection.Index == Int, DataCollection.Element: Identifiable
 	{
-		self.init(id: id, data: data, container: { $0 }, selectedItems: selectedItems, shouldAllowSelection: shouldAllowSelection, shouldAllowDeselection: shouldAllowDeselection, onCellEvent: onCellEvent, dragDropConfig: dragDropConfig, shouldAllowSwipeToDelete: shouldAllowSwipeToDelete, onSwipeToDelete: onSwipeToDelete, contextMenuProvider: contextMenuProvider, contentBuilder: contentBuilder)
+		self.init(id: id, data: data, container: { $0 }, selectedIndexes: selectedIndexes, shouldAllowSelection: shouldAllowSelection, shouldAllowDeselection: shouldAllowDeselection, onCellEvent: onCellEvent, dragDropConfig: dragDropConfig, shouldAllowSwipeToDelete: shouldAllowSwipeToDelete, onSwipeToDelete: onSwipeToDelete, contextMenuProvider: contextMenuProvider, contentBuilder: contentBuilder)
 	}
 }
 

--- a/Sources/ASCollectionView/Delegate/ASCollectionViewDelegate.swift
+++ b/Sources/ASCollectionView/Delegate/ASCollectionViewDelegate.swift
@@ -49,6 +49,14 @@ open class ASCollectionViewDelegate: NSObject, UICollectionViewDelegate, UIColle
 		coordinator?.collectionView(collectionView, didEndDisplayingSupplementaryView: view, forElementOfKind: elementKind, at: indexPath)
 	}
 
+	open func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+		coordinator?.collectionView(collectionView, shouldSelectItemAt: indexPath) ?? true
+	}
+
+	open func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
+		coordinator?.collectionView(collectionView, shouldDeselectItemAt: indexPath) ?? true
+	}
+
 	open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath)
 	{
 		coordinator?.collectionView(collectionView, didSelectItemAt: indexPath)

--- a/Sources/ASCollectionView/Implementation/ASSectionDataSource.swift
+++ b/Sources/ASCollectionView/Implementation/ASSectionDataSource.swift
@@ -28,6 +28,7 @@ internal protocol ASSectionDataSourceProtocol
 	func getContextMenu(for indexPath: IndexPath) -> UIContextMenuConfiguration?
 	func getSelfSizingSettings(context: ASSelfSizingContext) -> ASSelfSizingConfig?
 
+	func getSelectedIndexes() -> Set<Int>?
 	func isSelected(index: Int) -> Bool
 	func updateSelection(_ indices: Set<Int>)
 	func shouldSelect(_ indexPath: IndexPath) -> Bool
@@ -55,7 +56,7 @@ internal struct ASSectionDataSource<DataCollection: RandomAccessCollection, Data
 	var container: (Content) -> Container
 	var content: (DataCollection.Element, ASCellContext) -> Content
 
-	var selectedItems: Binding<Set<Int>>?
+	var selectedIndexes: Binding<Set<Int>>?
 	var shouldAllowSelection: ((_ index: Int) -> Bool)?
 	var shouldAllowDeselection: ((_ index: Int) -> Bool)?
 
@@ -281,28 +282,37 @@ internal struct ASSectionDataSource<DataCollection: RandomAccessCollection, Data
 		selfSizingConfig?(context)
 	}
 
+	func getSelectedIndexes() -> Set<Int>?
+	{
+		selectedIndexes?.wrappedValue
+	}
+
 	func isSelected(index: Int) -> Bool
 	{
-		selectedItems?.wrappedValue.contains(index) ?? false
+		selectedIndexes?.wrappedValue.contains(index) ?? false
 	}
 
 	func updateSelection(_ indices: Set<Int>)
 	{
 		DispatchQueue.main.async {
-			self.selectedItems?.wrappedValue = Set(indices)
+			self.selectedIndexes?.wrappedValue = Set(indices)
 		}
 	}
 
 	func shouldSelect(_ indexPath: IndexPath) -> Bool
 	{
-		guard data.containsIndex(indexPath.item) else { return (selectedItems != nil) }
-		return shouldAllowSelection?(indexPath.item) ?? (selectedItems != nil)
+		guard data.containsIndex(indexPath.item) else { return isSelectable }
+		return shouldAllowSelection?(indexPath.item) ?? isSelectable
 	}
 
 	func shouldDeselect(_ indexPath: IndexPath) -> Bool
 	{
-		guard data.containsIndex(indexPath.item) else { return (selectedItems != nil) }
-		return shouldAllowDeselection?(indexPath.item) ?? (selectedItems != nil)
+		guard data.containsIndex(indexPath.item) else { return isSelectable }
+		return shouldAllowDeselection?(indexPath.item) ?? isSelectable
+	}
+
+	private var isSelectable: Bool {
+		selectedIndexes != nil
 	}
 }
 


### PR DESCRIPTION
This pull request changes selection handling in `ASCollectionView` in a number of ways.

1. Remove the limitation on selection only being allowed while editing. Now, selection or multiple selection can be triggered enabled/disabled through the use of the `allowsSelection(_:)` and `allowsMultipleSelection(_:)` modifiers on `ASCollectionView`.
2. Rename `ASSection.selectedItems` to `selectedIndexes` to clarify the property holds indexes, not the model objects themselves.
3. Make `ASCollectionView` respond to changes to `selectedIndexes` from the SwiftUI side. In other words, the `Binding<Set<Int>>?` has become a true, two-way binding, which is [what Apple says `Binding`s should be](https://developer.apple.com/documentation/swiftui/binding#overview).
4. Add support for preventing selection/deselection for specific indexes in a section
5. Update Waterfall layout example to add a sheet detail view

The demo app's screens have been updated to reflect these changes.

Closes #176 