### PR TITLE
Add dodge keyboard modifier

### DIFF
--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -132,6 +132,13 @@ public extension ASCollectionView
 		this.maintainScrollPositionOnOrientationChange = true
 		return this
 	}
+    
+    /// Set whether the ASCollectionView should dodge the system keyboard
+    func shouldAvoidKeyboard(_ avoidKeyboard: Bool = true) -> Self {
+        var this = self
+        this.dodgeKeyboard = avoidKeyboard
+        return this
+    }
 }
 
 // MARK: PUBLIC layout modifier functions

--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -133,7 +133,8 @@ public extension ASCollectionView
 		return this
 	}
     
-    /// Set whether the ASCollectionView should dodge the system keyboard
+    /// Set whether the ASCollectionView should scroll the collection view in order to keep the current input field visible when the system keyboard appears.
+    /// The default value is `true`
     func shouldAvoidKeyboard(_ avoidKeyboard: Bool = true) -> Self {
         var this = self
         this.dodgeKeyboard = avoidKeyboard

--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -129,7 +129,7 @@ public extension ASCollectionView
 	func shouldAttemptToMaintainScrollPositionOnOrientationChange(maintainPosition: Bool) -> Self
 	{
 		var this = self
-		this.maintainScrollPositionOnOrientationChange = true
+		this.maintainScrollPositionOnOrientationChange = maintainPosition
 		return this
 	}
     


### PR DESCRIPTION
**1. What this PR does:**

This PR is about keyboard avoidance. Since iOS 14 beta 4, Apple added keyboard awareness to all the text entry fields. Unfortunately, this could break UIHostingControllers behavior (http://www.openradar.appspot.com/FB8176223).
ASCollectionView has an internal flag called `dodgeKeyboard ` that could help to mitigate this issue avoiding the inner calculation if it is not needed.

**2. Changes:**
- Adds a (missing?) modifier `shouldAvoidKeyboard(_ avoidKeyboard:)` that enable/disable the inner keyboard avoidance
- Fix `shouldAttemptToMaintainScrollPositionOnOrientationChange(maintainPosition:)` modifier, its input value wasn't used