### PR TITLE
Add backgroundColor to updateCollectionViewSettings

### DIFF
--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -183,6 +183,7 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 
 		func updateCollectionViewSettings(_ collectionView: UICollectionView)
 		{
+			assignIfChanged(collectionView, \.backgroundColor, newValue: parent.backgroundColor)
 			assignIfChanged(collectionView, \.dragInteractionEnabled, newValue: true)
 			assignIfChanged(collectionView, \.alwaysBounceVertical, newValue: parent.alwaysBounceVertical)
 			assignIfChanged(collectionView, \.alwaysBounceHorizontal, newValue: parent.alwaysBounceHorizontal)


### PR DESCRIPTION
This reverts what appears to be a bad merge in https://github.com/apptekstudios/ASCollectionView/commit/484a82d0e7d16359d593a2ff00a2b46dceb7d467#diff-7f9f29f1f24c322ca3c619f169098e877fa4e3df56da7732e282e3d4ec06857fL182

By adding the `ASCollectionView().backgroundColor` UIColor function to allow for background styling while preserving the automatic Navigation bar inline to large changes. 