### PR TITLE
added display callbacks

### DIFF
--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -104,7 +104,7 @@ public extension ASCollectionView
     func onDidDisplay(_ callback: ((UICollectionViewCell, IndexPath)->Void)?) -> Self
     {
         var this = self
-        this.onWillDisplay = callback
+        this.onDidDisplay = callback
         return this
     }
     

--- a/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASCollectionView+Modifiers.swift
@@ -1,6 +1,6 @@
 // ASCollectionView. Created by Apptek Studios 2019
 
-import Foundation
+import UIKit
 import SwiftUI
 
 // MARK: Modifer: Custom Delegate
@@ -92,6 +92,22 @@ public extension ASCollectionView
 		return this
 	}
 
+    /// Set a closure that is called when the collectionView will display a cell
+    func onWillDisplay(_ callback: ((UICollectionViewCell, IndexPath)->Void)?) -> Self
+    {
+        var this = self
+        this.onWillDisplay = callback
+        return this
+    }
+    
+    /// Set a closure that is called when the collectionView did display a cell
+    func onDidDisplay(_ callback: ((UICollectionViewCell, IndexPath)->Void)?) -> Self
+    {
+        var this = self
+        this.onWillDisplay = callback
+        return this
+    }
+    
 	/// Set a closure that is called when the collectionView is pulled to refresh
 	func onPullToRefresh(_ callback: ((_ endRefreshing: @escaping (() -> Void)) -> Void)?) -> Self
 	{

--- a/Sources/ASCollectionView/ASTableView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASTableView+Modifiers.swift
@@ -48,6 +48,22 @@ public extension ASTableView
 		this.contentInsets = insets
 		return this
 	}
+    
+    /// Set a closure that is called when the collectionView will display a cell
+    func onWillDisplay(_ callback: ((UITableViewCell, IndexPath)->Void)?) -> Self
+    {
+        var this = self
+        this.onWillDisplay = callback
+        return this
+    }
+    
+    /// Set a closure that is called when the collectionView did display a cell
+    func onDidDisplay(_ callback: ((UITableViewCell, IndexPath)->Void)?) -> Self
+    {
+        var this = self
+        this.onWillDisplay = callback
+        return this
+    }
 
 	/// Set a closure that is called when the tableView is pulled to refresh
 	func onPullToRefresh(_ callback: ((_ endRefreshing: @escaping (() -> Void)) -> Void)?) -> Self

--- a/Sources/ASCollectionView/ASTableView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASTableView+Modifiers.swift
@@ -61,7 +61,7 @@ public extension ASTableView
     func onDidDisplay(_ callback: ((UITableViewCell, IndexPath)->Void)?) -> Self
     {
         var this = self
-        this.onWillDisplay = callback
+        this.onDidDisplay = callback
         return this
     }
 

--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -36,6 +36,10 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 	internal var contentInsets: UIEdgeInsets = .zero
 
 	internal var onPullToRefresh: ((_ endRefreshing: @escaping (() -> Void)) -> Void)?
+    
+    internal var onWillDisplay: ((UICollectionViewCell, IndexPath) -> Void)?
+    
+    internal var onDidDisplay: ((UICollectionViewCell, IndexPath) -> Void)?
 
 	internal var alwaysBounceVertical: Bool = false
 	internal var alwaysBounceHorizontal: Bool = false
@@ -631,12 +635,14 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 			currentlyPrefetching.remove(indexPath)
 			parent.sections[safe: indexPath.section]?.dataSource.onAppear(indexPath)
 			queuePrefetch.send()
+            parent.onWillDisplay?(cell, indexPath)
 		}
 
 		public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath)
 		{
 			guard !indexPath.isEmpty else { return }
 			parent.sections[safe: indexPath.section]?.dataSource.onDisappear(indexPath)
+            parent.onDidDisplay?(cell, indexPath)
 		}
 
 		public func collectionView(_ collectionView: UICollectionView, willDisplaySupplementaryView view: UICollectionReusableView, forElementKind elementKind: String, at indexPath: IndexPath)

--- a/Sources/ASCollectionView/Implementation/ASTableView.swift
+++ b/Sources/ASCollectionView/Implementation/ASTableView.swift
@@ -35,6 +35,10 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 	internal var separatorsEnabled: Bool = true
 
 	internal var onPullToRefresh: ((_ endRefreshing: @escaping (() -> Void)) -> Void)?
+    
+    internal var onWillDisplay: ((UITableViewCell, IndexPath) -> Void)?
+    
+    internal var onDidDisplay: ((UITableViewCell, IndexPath) -> Void)?
 
 	internal var alwaysBounce: Bool = false
 	internal var animateOnDataRefresh: Bool = true
@@ -390,11 +394,14 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 		public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath)
 		{
 			parent.sections[safe: indexPath.section]?.dataSource.onAppear(indexPath)
-		}
+            parent.onWillDisplay?(cell,indexPath)
+        
+        }
 
 		public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath)
 		{
 			parent.sections[safe: indexPath.section]?.dataSource.onDisappear(indexPath)
+            parent.onDidDisplay?(cell,indexPath)
 		}
 
 		public func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int)


### PR DESCRIPTION
# Overview

The following PR implements the following modifiers both for UICollectionView and UITableView:

- willDisplay{ cell, indexPath in }
- didDisplay{ cell, indexPath in }

example:

```
        ASCollectionView(data: model.items, dataID: \.self) { item, context in
                
                InstaCard(model: instaCardModel(for: item),
                          geo: geo,
                          item: item){
                    model.open(newsItem: item)
                }
                
            }
            .layout {
                .list(itemSize:.estimated(123))
            }
            .onPullToRefresh { (finish) in
                model.loadNews()
                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                    finish()
                }
            }
            .onWillDisplay{ _, indexPath in
                player(at: indexPath)?.play()
            }
            .onDidDisplay{ _, indexPath in
                player(at: indexPath)?.pause()
            }
```