### PR TITLE
Add `dragDroppingItems` to accumulate changes & update `dragDropConfig.dataBinding` only once per drag-drop reorder

### DIFF
--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -794,6 +794,10 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 			guard let oldSnapshot = dataSource?.currentSnapshot else { return }
 			var dragSnapshot = oldSnapshot
 
+			parent.sections.forEach { section in
+				section.dataSource.applyPrepare()
+			}
+
 			switch coordinator.proposal.operation
 			{
 			case .move:
@@ -862,6 +866,10 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 				_ = destinationSection.dataSource.applyInsert(items: coordinator.items.map(\.dragItem), at: destinationIndexPath.item)
 
 			default: break
+			}
+
+			parent.sections.forEach { section in
+				section.dataSource.applyCommit()
 			}
 
 			if let dragItem = coordinator.items.first, let destination = coordinator.destinationIndexPath

--- a/Sources/ASCollectionView/Implementation/ASTableView.swift
+++ b/Sources/ASCollectionView/Implementation/ASTableView.swift
@@ -645,6 +645,10 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 			guard let oldSnapshot = dataSource?.currentSnapshot else { return }
 			var dragSnapshot = oldSnapshot
 
+			parent.sections.forEach { section in
+				section.dataSource.applyPrepare()
+			}
+
 			switch coordinator.proposal.operation
 			{
 			case .move:
@@ -713,6 +717,10 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 				_ = destinationSection.dataSource.applyInsert(items: coordinator.items.map(\.dragItem), at: destinationIndexPath.item)
 
 			default: break
+			}
+
+			parent.sections.forEach { section in
+				section.dataSource.applyCommit()
 			}
 
 			dataSource?.applySnapshot(dragSnapshot, animated: false)


### PR DESCRIPTION
Hi there 👋 

This PR adds an improvement in CollectionView (and also TableView)'s drag-drop reordering 
which **reduces "removed -> inserted" dance (2 calls) into 1 move only (1 call)**.

By applying this, I think **it will be more SwiftUI-engine-friendly to only have 1 update per `@Binding` change**.

Also, this fix is needed when CollectionView's items are derived from other single-source-of-truth via its state's binding transformation e.g. [this code](https://github.com/inamiy/Harvest/blob/a79e1be3586178fe28960c6ee2bd94dee7738b26/Sources/HarvestStore/Binding%2BHelper.swift#L6).

For example, if domain's `@ObservableObject` owns an array of `N` elements, and there's ViewModel that owns `N + 1` elements (`N` comes from domain, and additional 1 element is for view-specific reason), we will eventually map `$observableObject.item as Binding<[Domain.Item]>` to `Binding<[CollectionView.Item]>` by using the above `Binding.transform` (or similar) function.

But if "removed -> inserted" occurs inside ASCollectionView, it will be difficult for domain (user-side) to recover the inserted view-item back to domain-item because view-item is usually only a part of domain-item.
On the other side, if view-items are just reordered without item loss, it's easy for domain to reorder its domain-items since the order of view-item's ID only matters.

What do you think?

