### PR TITLE
Add `ASDragDropConfig.canDropItem`

### DIFF
--- a/Sources/ASCollectionView/ASDragDropConfig+Public.swift
+++ b/Sources/ASCollectionView/ASDragDropConfig+Public.swift
@@ -58,6 +58,14 @@ public extension ASDragDropConfig
 		return this
 	}
 
+	/// Called to check whether an item can be dropped
+	func canDropItem(_ closure: @escaping ((IndexPath) -> Bool)) -> Self
+	{
+		var this = self
+		this.canDropItem = closure
+		return this
+	}
+
 	/// An optional closure that you can use to decide what to do with a dropped item.
 	/// Return nil if you want to ignore the drop.
 	/// Return an item (of the same type as your section data) if you want to insert a row.

--- a/Sources/ASCollectionView/Config/ASDragDropConfig.swift
+++ b/Sources/ASCollectionView/Config/ASDragDropConfig.swift
@@ -29,6 +29,9 @@ public struct ASDragDropConfig<Data>
 	/// Called to check whether an item can be moved to the specified indexPath
 	var canMoveItem: ((_ sourceIndexPath: IndexPath, _ destinationIndexPath: IndexPath) -> Bool)?
 
+	/// Called to check whether an item can be dropped
+	var canDropItem: ((_ indexPath: IndexPath) -> Bool)?
+
 	var dragItemProvider: ((_ item: Data) -> NSItemProvider?)?
 
 	var dropItemProvider: ((_ sourceItem: Data?, _ dragItem: UIDragItem) -> Data?)?

--- a/Sources/ASCollectionView/Implementation/ASCollectionView.swift
+++ b/Sources/ASCollectionView/Implementation/ASCollectionView.swift
@@ -751,7 +751,9 @@ public struct ASCollectionView<SectionID: Hashable>: UIViewControllerRepresentab
 		func canDrop(at indexPath: IndexPath) -> Bool
 		{
 			guard !indexPath.isEmpty else { return false }
-			return parent.sections[safe: indexPath.section]?.dataSource.dropEnabled ?? false
+
+			return (parent.sections[safe: indexPath.section]?.dataSource.dropEnabled ?? false)
+				&& (parent.sections[safe: indexPath.section]?.dataSource.canDropItem?(indexPath) ?? true)
 		}
 
 		func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem]

--- a/Sources/ASCollectionView/Implementation/ASSectionDataSource.swift
+++ b/Sources/ASCollectionView/Implementation/ASSectionDataSource.swift
@@ -45,6 +45,7 @@ internal protocol ASSectionDataSourceProtocol
 
 	var dragEnabled: Bool { get }
 	var dropEnabled: Bool { get }
+	var canDropItem: ((IndexPath) -> Bool)? { get }
 	var reorderingEnabled: Bool { get }
 
 	mutating func setSelfSizingConfig(config: @escaping SelfSizingConfig)
@@ -100,6 +101,7 @@ internal struct ASSectionDataSource<DataCollection: RandomAccessCollection, Data
 
 	var dragEnabled: Bool { dragDropConfig.dragEnabled }
 	var dropEnabled: Bool { dragDropConfig.dropEnabled }
+	var canDropItem: ((IndexPath) -> Bool)? { dragDropConfig.canDropItem }
 	var reorderingEnabled: Bool { dragDropConfig.reorderingEnabled }
 
 	var endIndex: Int { data.endIndex }


### PR DESCRIPTION
This PR adds `ASDragDropConfig.canDropItem` to prevent from dropping item "without cell-shifting animation".

Please note that this behavior is different from `ASDragDropConfig.canMoveItem` where item can't also be dropped by this configuration but still allows cell-shifting animation to make the current dragging place an empty space until dragging is finished.

### Screencast

https://user-images.githubusercontent.com/138476/110242398-3b818580-7f99-11eb-9161-b07b4cf53e1c.mp4

First item is not droppable by following configuration:

```swift
    var dragDropConfig: ASDragDropConfig<Item> {
        ASDragDropConfig<Item>(dataBinding: $items)
            .canDragItem { $0.row != 0 }
            .canDropItem { $0.row != 0 } // First item is not droppable or move to make empty space
    }
```