### PR TITLE
Support for disabling keyboard show/hide handling in ASTableView

### DIFF
--- a/Sources/ASCollectionView/ASTableView+Modifiers.swift
+++ b/Sources/ASCollectionView/ASTableView+Modifiers.swift
@@ -97,6 +97,14 @@ public extension ASTableView
 		this.scrollPositionSetter = binding
 		return this
 	}
+
+	/// Set whether the TableView should handle keyboard appearance and disappearance
+	func shouldHandleKeyboardAppearance(_ isEnabled: Bool) -> Self
+	{
+		var this = self
+		this.shouldHandleKeyboardAppereance = isEnabled
+		return this
+	}
 }
 
 // MARK: ASTableView specific header modifiers

--- a/Sources/ASCollectionView/Implementation/ASTableView.swift
+++ b/Sources/ASCollectionView/Implementation/ASTableView.swift
@@ -45,6 +45,8 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 
 	internal var dodgeKeyboard: Bool = true
 
+	internal var shouldHandleKeyboardAppereance: Bool = true
+
 	// MARK: Environment variables
 
 	@Environment(\.invalidateCellLayout) var invalidateParentCellLayout // Call this if using content size binding (nested inside another ASCollectionView)
@@ -823,6 +825,10 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 			}
 		}
 
+		var shouldHandleKeyboardAppereance: Bool {
+			parent.shouldHandleKeyboardAppereance
+		}
+
 		var extraKeyboardSpacing: CGFloat = 25
 		func setupKeyboardObservers()
 		{
@@ -866,6 +872,7 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 
 		@objc func keyBoardWillShow(notification: Notification)
 		{
+			guard shouldHandleKeyboardAppereance else { return }
 			guard containsFirstResponder()
 			else
 			{
@@ -892,6 +899,8 @@ public struct ASTableView<SectionID: Hashable>: UIViewControllerRepresentable, C
 
 		@objc func keyBoardWillHide(notification _: Notification)
 		{
+			guard shouldHandleKeyboardAppereance else { return }
+
 			keyboardFrame = nil
 			tableViewController?.tableView.layoutIfNeeded()
 		}


### PR DESCRIPTION
I recently stumbled upon the need to disable keyboard handling in ASTableView due to the new better handling of keyboard appearance in SwiftUI >= 2. This PR adds a view modifier to ASTableView to do achieve that.

Not sure whether is worth having the same logic applied to ASCollectionView too.