### PR TITLE
All prepareForReuse() overrides skipped the superclass call, causing corrupted self-sizing layouts.

### DIFF
--- a/Sources/ASCollectionView/Cells/ASCollectionViewCell.swift
+++ b/Sources/ASCollectionView/Cells/ASCollectionViewCell.swift
@@ -40,6 +40,7 @@ class ASCollectionViewCell: UICollectionViewCell, ASDataSourceConfigurableCell
 
 	override func prepareForReuse()
 	{
+		super.prepareForReuse()
 		itemID = nil
 		isSelected = false
 		alpha = 1.0

--- a/Sources/ASCollectionView/Cells/ASCollectionViewDecoration.swift
+++ b/Sources/ASCollectionView/Cells/ASCollectionViewDecoration.swift
@@ -18,9 +18,4 @@ class ASCollectionViewDecoration<Content: Decoration>: ASCollectionViewSupplemen
 		super.init(frame: frame)
 		setContent(supplementaryID: ASSupplementaryCellID(sectionIDHash: 0, supplementaryKind: "Decoration"), content: Content())
 	}
-
-	override func prepareForReuse()
-	{
-		// Don't call super, we don't want any changes
-	}
 }

--- a/Sources/ASCollectionView/Cells/ASCollectionViewSupplementaryView.swift
+++ b/Sources/ASCollectionView/Cells/ASCollectionViewSupplementaryView.swift
@@ -40,6 +40,7 @@ class ASCollectionViewSupplementaryView: UICollectionReusableView, ASDataSourceC
 
 	override func prepareForReuse()
 	{
+		super.prepareForReuse()
 		supplementaryID = nil
 	}
 

--- a/Sources/ASCollectionView/Cells/ASTableViewCell.swift
+++ b/Sources/ASCollectionView/Cells/ASTableViewCell.swift
@@ -45,6 +45,8 @@ class ASTableViewCell: UITableViewCell, ASDataSourceConfigurableCell
 
 	override func prepareForReuse()
 	{
+		super.prepareForReuse()
+
 		itemID = nil
 		isSelected = false
 		backgroundColor = nil

--- a/Sources/ASCollectionView/Cells/ASTableViewSupplementaryView.swift
+++ b/Sources/ASCollectionView/Cells/ASTableViewSupplementaryView.swift
@@ -39,6 +39,7 @@ class ASTableViewSupplementaryView: UITableViewHeaderFooterView, ASDataSourceCon
 
 	override func prepareForReuse()
 	{
+		super.prepareForReuse()
 		supplementaryID = nil
 	}
 


### PR DESCRIPTION
### Collection reusable view should call `super.prepareForReuse()`.

The UICollectionViewLayout preferred layout attributes mechanism apparently holds internal states inside the cells/reusable views, which needs to be reset by `super.prepareForReuse()` before the cell is reused.

Since `ASCollectionViewCell` does not call `super.prepareForResue()`, those states are not being reset. This causes UIKit to consider a reused cell bound to a new index path has been already measured for preferred attributes, when it goes on screen. Therefore, reused cells are often stuck at the estimated size, where the whole preferred layout attributes lifecycle stops happening at all, while supposedly it should trigger every time the item goes on screen.

In order words, this causes issues with both `UICollectionViewCompositionalLayout`, `UICollectionViewFlowLayout`, and any custom layout that relies on preferred layout attributes on content self-sizing. Tested on both iOS 13.4 and 14.5.

### UITableView cells should call `super.prepareForReuse()`.

> https://developer.apple.com/documentation/uikit/uitableviewcell/1623223-prepareforreuse
>
> [...] If you override this method, you must be sure to invoke the superclass implementation. 