### PR TITLE
Fix AttributeGraph Cycle Issues

### DIFF
--- a/Sources/ASCollectionView/Datasource/ASDiffableDataSourceCollectionView.swift
+++ b/Sources/ASCollectionView/Datasource/ASDiffableDataSourceCollectionView.swift
@@ -40,18 +40,15 @@ class ASDiffableDataSourceCollectionView<SectionID: Hashable>: ASDiffableDataSou
 				self.currentSnapshot = .init(sections: newSections)
 			}
 		}
-		CATransaction.begin()
-		CATransaction.setCompletionBlock(completion)
 		if firstLoad || !animated
 		{
-			CATransaction.setDisableActions(true)
-			apply()
+		        UIView.performWithoutAnimation(apply)
 		}
 		else
 		{
 			apply()
 		}
-		CATransaction.commit()
+                completion?()
 		firstLoad = false
 	}
 


### PR DESCRIPTION
When using ASCollectionView in a very specific way:

1. Using an `@ObservedObject` as a data source for the sections
2. Embedding SwiftUI via a UIHostingController as a *child* of an existing UIViewController

There are some AttributeGraph cycle warnings that appear in the logs. I've tracked these down to a nested CATransaction used to disable animations during the batch updates of the changes.

I'm not entirely sure *why* AttributeGraph complains about cycles and they only occur once per ASCollectionView. They also don't seem to cause any obvious issues but I'm not one to ship production code with warnings about "cycles".

In the past I've always used the UIView.performWithoutAnimation API and decided to try it instead of the CATransaction code and it still works as well as rids the AttributeGraph cycle issues.